### PR TITLE
Support invoking without parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import localStorage from 'ember-local-storage-decorator';
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {
-  @localStorage() foo
+  @localStorage foo
 }
 ```
 
@@ -38,7 +38,7 @@ to write changes to `localStorage`.
 
 ```js
 const Klass = class {
-  @localStorage() foo;
+  @localStorage foo;
 }
 const klass = new Klass();
 
@@ -69,7 +69,7 @@ frozen copy after setting a value.
 window.localStorage.setItem('foo', [{ a: 'b' }]);
 
 const Klass = class {
-  @localStorage() foo;
+  @localStorage foo;
 };
 const klass = new Klass();
 
@@ -87,10 +87,10 @@ It observes changes caused by other classes or by other instances:
 
 ```js
 const KlassA = class {
-  @localStorage() foo;
+  @localStorage foo;
 };
 const KlassB = class {
-  @localStorage() foo;
+  @localStorage foo;
 }
 const klassA = new KlassA();
 const klassB = new KlassB();

--- a/tests/unit/decorators/local-storage-test.js
+++ b/tests/unit/decorators/local-storage-test.js
@@ -30,6 +30,16 @@ module('Unit | Decorator | @localStorage', function (hooks) {
     });
   });
 
+  module('optional parentheses', function () {
+    test('it can be invoked without parentheses', function (assert) {
+      const klass = new (class {
+        @localStorage foo = 'no parentheses';
+      })();
+
+      assert.equal(klass.foo, 'no parentheses');
+    });
+  });
+
   module('getter', function () {
     test('picks up simple value from local storage', function (assert) {
       window.localStorage.setItem('foo', JSON.stringify('baz'));


### PR DESCRIPTION
This PR makes it possible to invoke the decorator without the parentheses if no custom key is needed.

Closes #11 