### PR TITLE
Disable tests for Ember v5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,9 @@ jobs:
           # ember-classic
         ]
         allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
+        # include:
+        #  - ember-try-scenario: ember-canary
+        #    allow-failure: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,9 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.28,
           ember-lts-4.4,
-          ember-release,
-          ember-beta,
-          ember-classic
+          # ember-release,
+          # ember-beta,
+          # ember-classic
         ]
         allow-failure: [false]
         include:


### PR DESCRIPTION
Addon is not compatible with Ember v5 yet. We can and should enable those tests again after incompatibility has been resolved.